### PR TITLE
Add visual studio 2022 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
  - [DLL Patches](https://github.com/P0L3NARUBA/gtav-sourcecode-build-guide/files/14965810/dll_patches_x.zip)
  - (OPTIONAL) [3rdParty Folder](https://mega.nz/file/SqojFJZL#eYINo1pnspuTvdbocz4cA7NYZA8BN2H2nm7YEXuzlFw)
  - (OPTIONAL) [gIKgDXuVHNzIgXkiwpB.zip - Art Asset Leak](https://big.fileditchnew.ch/b9/gIKgDXuVHNzIgXkiwpB.zip)
+ - (OPTIONAL) [Visual Studio 2022 patches](https://small.fileditchstuff.me/s10/VBlSfKBylNQplMIPLL.zip) [mirror](https://file.io/kR8rjHSociys)
 
 ## Prebuilt Files
  - [Shaders](https://github.com/WH0LEWHALE/gtav-sourcecode-build-guide/files/14649717/common.zip)


### PR DESCRIPTION
I was able to successfully compile and run the game (BankRelease) for Visual Studio 2022 (v143) using the latest Windows 11 SDK. Seems to be working fine. Feel free to let me know if you encounter any issues. 
Unzip and overwrite all folders. Open the "game_2012_unity" project and build it. No need to make any other changes.